### PR TITLE
Remediating open security vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,13 @@ Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.3.2
 idna==2.8
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.1.0
 psycopg2==2.7.7
 python-dotenv==0.10.1
 pytz==2018.9
 requests==2.21.0
 six==1.12.0
-SQLAlchemy==1.2.17
+SQLAlchemy==1.3.0
 urllib3==1.24.1
 Werkzeug==0.14.1


### PR DESCRIPTION
Jinja2
CVE-2019-10906
More information
high severity
Vulnerable versions: < 2.10.1
Patched version: 2.10.1

In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.

SQLAlchemy

CVE-2019-7164
More information
moderate severity
Vulnerable versions: < 1.3.0
Patched version: 1.3.0

SQLAlchemy through 1.2.17 and 1.3.x through 1.3.0b2 allows SQL Injection via the order_by parameter.

CVE-2019-7548
More information
moderate severity
Vulnerable versions: < 1.3.0
Patched version: 1.3.0

SQLAlchemy 1.2.17 has SQL Injection when the group_by parameter can be controlled.